### PR TITLE
Add new promo: Inquirer PA2020

### DIFF
--- a/src/modules/gen_html/gen_jinja_vars.py
+++ b/src/modules/gen_html/gen_jinja_vars.py
@@ -1,8 +1,5 @@
 from src.modules.helper.formatters import format_commas
-from src.modules.helper.time import (
-    est_now_formatted_brief,
-    est_now_ap_brief,
-)
+from src.modules.helper.time import est_now_ap_brief
 from typing import List, Dict
 
 
@@ -27,6 +24,18 @@ def gen_jinja_vars(
         
     """
     brief_date = est_now_ap_brief()
+    promo_1_url = (
+        "https://www.inquirer.com/newsletters/election/sign-up/?utm_source=email&utm_campaign=mktg_pa2020_"
+        "leadgen&utm_medium=referral&utm_content=spotlightpa&utm_term=&int_promo="
+    )
+    promo_1_tagline = (
+        "<strong>Pennsylvania is a critical state in determining who wins the White House this "
+        "year</strong>. The "
+        "Philadelphia Inquirer just launched a weekly newsletter with exclusive reporting covering "
+        "the entire state on issues that impact you, plus fact-checks, guides to voting, and more. "
+        f'Sign up to follow along at <a href="{promo_1_url}" target="_blank">Inquirer.com/PA2020</a>.'
+    )
+
     payload = {
         "head": {
             "title": f"The latest COVID-19 statistics for {county_name} from Spotlight PA."
@@ -40,10 +49,9 @@ def gen_jinja_vars(
         },
         "promos": {
             1: {
-                "image_path": "https://interactives.data.spotlightpa.org/assets/promos/newsletter-promo__investigator"
-                ".png",
-                "url": "https://www.spotlightpa.org/newsletters/",
-                "tagline": "Sign up for a weekly round-up of Pennsylvania's best accountability reporting.",
+                "image_path": "https://interactives.data.spotlightpa.org/assets/promos/pa2020_300x250.png",
+                "url": promo_1_url,
+                "tagline": promo_1_tagline,
             }
         },
         "section_welcome": f"{brief_date}: Read on for more information about how cases, deaths, and tests are trending "

--- a/src/modules/gen_html/gen_jinja_vars.py
+++ b/src/modules/gen_html/gen_jinja_vars.py
@@ -49,7 +49,7 @@ def gen_jinja_vars(
         },
         "promos": {
             1: {
-                "image_path": "https://interactives.data.spotlightpa.org/assets/promos/pa2020_300x250.png",
+                "image_path": "https://interactives.data.spotlightpa.org/assets/promos/newsletter-promo__pa2020.png",
                 "url": promo_1_url,
                 "tagline": promo_1_tagline,
             }

--- a/src/templates/body_section_promo1.html
+++ b/src/templates/body_section_promo1.html
@@ -6,7 +6,7 @@
         </a>
 
         <div class="promo1__tagline">
-            <a href="{{promos.1.url}}" target="_blank">{{ promos.1.tagline }}</a>
+            <span>{{ promos.1.tagline }}</span>
         </div>
         <hr class="promo__divider-bottom">
     </div>

--- a/src/templates/styles/index.css
+++ b/src/templates/styles/index.css
@@ -470,7 +470,6 @@
     }
 
     .promo__container {
-        text-align: center;
         padding-bottom: 6px;
     }
 
@@ -488,7 +487,9 @@
 
 
     .promo1__tagline {
+        margin-top: 6px;
         font-size: 14px;
+        text-align: left;
     }
 
     @media only screen and (max-width: 480px){

--- a/src/templates/styles/index.css
+++ b/src/templates/styles/index.css
@@ -488,7 +488,7 @@
 
     .promo1__tagline {
         margin-top: 6px;
-        font-size: 14px;
+        font-size: 16px;
         text-align: left;
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,11 @@ import csv
 from src.modules.process_data.process_stories import process_stories
 
 # don't send emails during full testing suite runs
-collect_ignore_glob = ["*test_prod_email.py", "*test_email.py"]
+collect_ignore_glob = [
+    "*test_prod_email.py",
+    "*test_email.py",
+    "*test_full_with_email.py",
+]
 
 
 def pytest_configure(config):

--- a/tests/test_full_no_email.py
+++ b/tests/test_full_no_email.py
@@ -4,7 +4,7 @@ from src.definitions import AWS_DIR_TEST
 
 
 def test_full_dauphin_county(dauphin_county_dict):
-    """ A full program run using just a single county """
+    """ A full program run using just a single county BUT no email will be sent at end. """
     county_name = dauphin_county_dict["42043"]["name"]
     subject = (
         f"COVID-19 Report FULL-RUN TEST: {county_name}, {random.randint(0,999999)}"
@@ -18,7 +18,7 @@ def test_full_dauphin_county(dauphin_county_dict):
 
 
 def test_full_phila_county(phila_county_dict):
-    """ A full program run using just a single county """
+    """ A full program run using just a single county BUT no email will be sent at end. """
     county_name = phila_county_dict["42101"]["name"]
     subject = (
         f"COVID-19 Report FULL-RUN TEST: {county_name}, {random.randint(0,999999)}"
@@ -32,7 +32,7 @@ def test_full_phila_county(phila_county_dict):
 
 
 def test_full_greene_county(greene_county_dict):
-    """ A full program run using just a single county """
+    """ A full program run using just a single county BUT no email will be sent at end. """
     county_name = greene_county_dict["42059"]["name"]
     subject = (
         f"COVID-19 Report FULL-RUN TEST: {county_name}, {random.randint(0,999999)}"
@@ -46,6 +46,7 @@ def test_full_greene_county(greene_county_dict):
 
 
 def test_full_multi_county(multi_county_dict):
+    """ A full program run using multiple counties BUT no emails will be sent at end. """
     subject = f"COVID-19 Report FULL-RUN MULTI-COUNTY TEST: {random.randint(0,999999)}"
     main(
         multi_county_dict,

--- a/tests/test_full_with_email.py
+++ b/tests/test_full_with_email.py
@@ -1,0 +1,28 @@
+from src.covid_email_alerts import main
+import random
+from src.definitions import AWS_DIR_TEST
+
+
+def test_full_dauphin_county(dauphin_county_dict):
+    """ A full program run using just a single county """
+    county_name = dauphin_county_dict["42043"]["name"]
+    subject = (
+        f"COVID-19 Report FULL-RUN TEST: {county_name}, {random.randint(0,999999)}"
+    )
+    main(
+        dauphin_county_dict,
+        custom_subject_line=subject,
+        aws_dir=AWS_DIR_TEST,
+        email_send=True,
+    )
+
+
+def test_full_multi_county(multi_county_dict):
+    """ A full program run using multiple counties. """
+    subject = f"COVID-19 Report FULL-RUN MULTI-COUNTY TEST: {random.randint(0,999999)}"
+    main(
+        multi_county_dict,
+        custom_subject_line=subject,
+        aws_dir=AWS_DIR_TEST,
+        email_send=True,
+    )


### PR DESCRIPTION
- Replace promo for The Investigator with promo for the Inquirer's PA2020 newsletter
- Split up full run test module into two module: one module that has various tests that will run the entire app but not send emails, and a second module that performs full run of the app and will send emails at the conclusion. The latter will be triggered when 'pytest' is run along with other tests, the former will be excluded and can only be triggered by specifically calling that module or the functions inside of it. This is so folks on our testing email list aren't spammed with emails during every run of pytest.